### PR TITLE
Feat/posesync

### DIFF
--- a/include/NodePoseSyncState/MpNodePoseSyncStateManager.hpp
+++ b/include/NodePoseSyncState/MpNodePoseSyncStateManager.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "custom-types/shared/macros.hpp"
+#include "lapiz/shared/macros.hpp"
+
+#include "GlobalNamespace/NodePoseSyncStateManager.hpp"
+#include "MpNodePoseSyncStatePacket.hpp"
+#include "Networking/MpPacketSerializer.hpp"
+#include "System/IDisposable.hpp"
+#include "Zenject/IInitializable.hpp"
+
+DECLARE_CLASS_CODEGEN(MultiplayerCore::NodePoseSyncState, MpNodePoseSyncStateManager, GlobalNamespace::NodePoseSyncStateManager,
+    DECLARE_INSTANCE_FIELD_PRIVATE(Networking::MpPacketSerializer*, _packetSerializer);
+    DECLARE_INSTANCE_FIELD_PRIVATE(float, deltaUpdateFrequency);
+    DECLARE_INSTANCE_FIELD_PRIVATE(float, fullStateUpdateFrequency);
+
+    DECLARE_OVERRIDE_METHOD(float, get_deltaUpdateFrequency, il2cpp_utils::il2cpp_type_check::MetadataGetter<&GlobalNamespace::NodePoseSyncStateManager::get_deltaUpdateFrequency>::get());
+    DECLARE_OVERRIDE_METHOD(float, get_fullStateUpdateFrequency, il2cpp_utils::il2cpp_type_check::MetadataGetter<&GlobalNamespace::NodePoseSyncStateManager::get_fullStateUpdateFrequency>::get());
+
+    DECLARE_INJECT_METHOD(void, Inject, Networking::MpPacketSerializer* packetSerializer);
+
+    DECLARE_OVERRIDE_METHOD(void, Initialize, il2cpp_utils::il2cpp_type_check::MetadataGetter<&Zenject::IInitializable::Initialize>::get());
+    DECLARE_OVERRIDE_METHOD(void, Dispose, il2cpp_utils::il2cpp_type_check::MetadataGetter<&System::IDisposable::Dispose>::get());
+
+    DECLARE_CTOR(ctor);
+
+    public:
+        void HandleNodePoseSyncUpdateReceived(MpNodePoseSyncStatePacket* data, GlobalNamespace::IConnectedPlayer* player);
+)

--- a/include/NodePoseSyncState/MpNodePoseSyncStateManager.hpp
+++ b/include/NodePoseSyncState/MpNodePoseSyncStateManager.hpp
@@ -9,7 +9,7 @@
 #include "System/IDisposable.hpp"
 #include "Zenject/IInitializable.hpp"
 
-DECLARE_CLASS_CODEGEN(MultiplayerCore::NodePoseSyncState, MpNodePoseSyncStateManager, GlobalNamespace::NodePoseSyncStateManager,
+DECLARE_CLASS_CODEGEN_INTERFACES(MultiplayerCore::NodePoseSyncState, MpNodePoseSyncStateManager, GlobalNamespace::NodePoseSyncStateManager, std::vector<Il2CppClass*>({classof(Zenject::IInitializable*), classof(System::IDisposable*)}),
     DECLARE_INSTANCE_FIELD_PRIVATE(Networking::MpPacketSerializer*, _packetSerializer);
     DECLARE_INSTANCE_FIELD_PRIVATE(float, deltaUpdateFrequency);
     DECLARE_INSTANCE_FIELD_PRIVATE(float, fullStateUpdateFrequency);

--- a/include/NodePoseSyncState/MpNodePoseSyncStatePacket.hpp
+++ b/include/NodePoseSyncState/MpNodePoseSyncStatePacket.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Networking/Abstractions/MpPacket.hpp"
+
+DECLARE_CLASS_CUSTOM(MultiplayerCore::NodePoseSyncState, MpNodePoseSyncStatePacket, MultiplayerCore::Networking::Abstractions::MpPacket,
+    DECLARE_INSTANCE_FIELD(float, deltaUpdateFrequency);
+    DECLARE_INSTANCE_FIELD(float, fullStateUpdateFrequency);
+
+    DECLARE_OVERRIDE_METHOD(void, Serialize, il2cpp_utils::il2cpp_type_check::MetadataGetter<&LiteNetLib::Utils::INetSerializable::Serialize>::get(), LiteNetLib::Utils::NetDataWriter* writer);
+    DECLARE_OVERRIDE_METHOD(void, Deserialize, il2cpp_utils::il2cpp_type_check::MetadataGetter<&LiteNetLib::Utils::INetSerializable::Deserialize>::get(), LiteNetLib::Utils::NetDataReader* reader);
+
+    DECLARE_CTOR(ctor);
+)

--- a/src/Hooks/MainSystemBinderHooks.cpp
+++ b/src/Hooks/MainSystemBinderHooks.cpp
@@ -3,11 +3,14 @@
 
 #include "lapiz/shared/arrayutils.hpp"
 #include "GlobalNamespace/MainSystemInit.hpp"
+#include "GlobalNamespace/NodePoseSyncStateManager.hpp"
+#include "GlobalNamespace/INodePoseSyncStateManager.hpp"
 #include "Zenject/DiContainer.hpp"
 #include "Zenject/ConcreteIdBinderGeneric_1.hpp"
 #include "Zenject/ConcreteIdBinderNonGeneric.hpp"
 #include "Zenject/FromBinderNonGeneric.hpp"
 #include "Objects/MpEntitlementChecker.hpp"
+#include "NodePoseSyncState/MpNodePoseSyncStateManager.hpp"
 
 MAKE_AUTO_HOOK_ORIG_MATCH(MainSystemInit_InstallBindings, &::GlobalNamespace::MainSystemInit::InstallBindings, void, GlobalNamespace::MainSystemInit* self, Zenject::DiContainer* container) {
     MainSystemInit_InstallBindings(self, container);
@@ -16,4 +19,11 @@ MAKE_AUTO_HOOK_ORIG_MATCH(MainSystemInit_InstallBindings, &::GlobalNamespace::Ma
     auto bindarray = Lapiz::ArrayUtils::TypeArray<GlobalNamespace::NetworkPlayerEntitlementChecker*>();
     auto toarray = Lapiz::ArrayUtils::TypeArray<MultiplayerCore::Objects::MpEntitlementChecker*>();
     container->Bind(reinterpret_cast<::System::Collections::Generic::IEnumerable_1<System::Type*>*>(bindarray.convert()))->To(reinterpret_cast<::System::Collections::Generic::IEnumerable_1<System::Type*>*>(toarray.convert()))->FromNewComponentOnRoot()->AsSingle()->NonLazy();
+
+    container->Unbind<GlobalNamespace::NodePoseSyncStateManager*>();
+    container->Unbind<GlobalNamespace::INodePoseSyncStateManager*>();
+
+    bindarray = Lapiz::ArrayUtils::TypeArray<MultiplayerCore::NodePoseSyncState::MpNodePoseSyncStateManager*, GlobalNamespace::NodePoseSyncStateManager*, GlobalNamespace::INodePoseSyncStateManager*, Zenject::IInitializable*, System::IDisposable*>();
+    toarray = Lapiz::ArrayUtils::TypeArray<MultiplayerCore::NodePoseSyncState::MpNodePoseSyncStateManager*>();
+    container->Bind(reinterpret_cast<::System::Collections::Generic::IEnumerable_1<System::Type*>*>(bindarray.convert()))->To(reinterpret_cast<::System::Collections::Generic::IEnumerable_1<System::Type*>*>(toarray.convert()))->FromNewComponentOnRoot()->AsSingle();
 }

--- a/src/NodePoseSyncState/MpNodePoseSyncStateManager.cpp
+++ b/src/NodePoseSyncState/MpNodePoseSyncStateManager.cpp
@@ -1,0 +1,35 @@
+#include "NodePoseSyncState/MpNodePoseSyncStateManager.hpp"
+
+DEFINE_TYPE(MultiplayerCore::NodePoseSyncState, MpNodePoseSyncStateManager);
+
+namespace MultiplayerCore::NodePoseSyncState {
+    void MpNodePoseSyncStateManager::ctor() {
+        INVOKE_BASE_CTOR(classof(GlobalNamespace::NodePoseSyncStateManager*));
+        deltaUpdateFrequency = 0.01f;
+        fullStateUpdateFrequency = 0.1f;
+    }
+
+    void MpNodePoseSyncStateManager::Inject(Networking::MpPacketSerializer* packetSerializer) {
+        _packetSerializer = packetSerializer;
+    }
+
+    void MpNodePoseSyncStateManager::Initialize() {
+        _packetSerializer->RegisterCallback<MpNodePoseSyncStatePacket*>(
+            std::bind(&MpNodePoseSyncStateManager::HandleNodePoseSyncUpdateReceived, this, std::placeholders::_1, std::placeholders::_2)
+        );
+    }
+
+    void MpNodePoseSyncStateManager::Dispose() {
+        _packetSerializer->UnregisterCallback<MpNodePoseSyncStatePacket*>();
+    }
+
+    void MpNodePoseSyncStateManager::HandleNodePoseSyncUpdateReceived(MpNodePoseSyncStatePacket* data, GlobalNamespace::IConnectedPlayer* player) {
+        if (player->get_isConnectionOwner()) {
+            deltaUpdateFrequency = data->deltaUpdateFrequency;
+            fullStateUpdateFrequency= data->fullStateUpdateFrequency;
+        }
+    }
+
+    float MpNodePoseSyncStateManager::get_deltaUpdateFrequency() { return deltaUpdateFrequency; }
+    float MpNodePoseSyncStateManager::get_fullStateUpdateFrequency() { return fullStateUpdateFrequency; }
+}

--- a/src/NodePoseSyncState/MpNodePoseSyncStatePacket.cpp
+++ b/src/NodePoseSyncState/MpNodePoseSyncStatePacket.cpp
@@ -1,0 +1,19 @@
+#include "NodePoseSyncState/MpNodePoseSyncStatePacket.hpp"
+
+DEFINE_TYPE(MultiplayerCore::NodePoseSyncState, MpNodePoseSyncStatePacket);
+
+namespace MultiplayerCore::NodePoseSyncState {
+    void MpNodePoseSyncStatePacket::ctor() {
+        INVOKE_BASE_CTOR(classof(MultiplayerCore::Networking::Abstractions::MpPacket*));
+    }
+
+    void MpNodePoseSyncStatePacket::Serialize(LiteNetLib::Utils::NetDataWriter* writer) {
+        writer->Put(deltaUpdateFrequency);
+        writer->Put(fullStateUpdateFrequency);
+    }
+
+    void MpNodePoseSyncStatePacket::Deserialize(LiteNetLib::Utils::NetDataReader* reader) {
+        deltaUpdateFrequency = reader->GetFloat();
+        fullStateUpdateFrequency = reader->GetFloat();
+    }
+}


### PR DESCRIPTION
 replaces the normal pose sync manager with a custom one that can be controlled with packets from the server, allowing the server to scale back the amount of movement packets sent by clients